### PR TITLE
fix: add MMConsole in a QWidget 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "ndv[vispy]==0.0.4",
+    "ndv[vispy] @ git+https://github.com/pyapp-kit/ndv@main",
     "pymmcore-plus[cli]>=0.12.0",
     "pymmcore-widgets>=0.8.0",
     "PyQt6==6.7.1",
@@ -64,6 +64,9 @@ dev = [
     "rust-just>=1.38.0",
     "types-pyautogui>=0.9.3.20241230",
 ]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 # same as console_scripts entry point
 [project.scripts]

--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -24,6 +24,7 @@ from pymmcore_gui.actions.widget_actions import WidgetActionInfo
 
 from .actions import CoreAction, WidgetAction
 from .actions._action_info import ActionKey
+from .core_link._core_link import CoreViewersLink
 from .widgets._toolbars import OCToolBar, ShuttersToolbar
 
 if TYPE_CHECKING:
@@ -109,6 +110,8 @@ class MicroManagerGUI(QMainWindow):
 
         # get global CMMCorePlus instance
         self._mmc = mmc = mmcore or CMMCorePlus.instance()
+
+        self._core_link = CoreViewersLink(self, mmcore=self._mmc)
 
         # MENUS ====================================
         # To add menus or menu items, add them to the MENUS dict above

--- a/src/pymmcore_gui/actions/widget_actions.py
+++ b/src/pymmcore_gui/actions/widget_actions.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, cast
 
 from pymmcore_plus import CMMCorePlus
 from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QVBoxLayout, QWidget
 
 from pymmcore_gui.actions._action_info import ActionKey
 
@@ -17,7 +18,6 @@ if TYPE_CHECKING:
 
     import pymmcore_widgets as pmmw
     from PyQt6.QtCore import QObject
-    from PyQt6.QtWidgets import QWidget
 
     from pymmcore_gui._main_window import MicroManagerGUI
     from pymmcore_gui.widgets._mm_console import MMConsole
@@ -54,7 +54,11 @@ def create_mm_console(parent: QWidget) -> MMConsole:
     """Create a console widget."""
     from pymmcore_gui.widgets._mm_console import MMConsole
 
-    return MMConsole(parent=parent)
+    wdg = QWidget(parent=parent)
+    layout = QVBoxLayout(wdg)
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.addWidget(MMConsole(parent=wdg))
+    return wdg
 
 
 def create_install_widgets(parent: QWidget) -> pmmw.InstallWidget:

--- a/src/pymmcore_gui/core_link/_core_link.py
+++ b/src/pymmcore_gui/core_link/_core_link.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ndv import ArrayViewer
+from pymmcore_plus import CMMCorePlus
+from pymmcore_plus.mda.handlers import TensorStoreHandler
+from qtpy.QtCore import QObject
+
+if TYPE_CHECKING:
+    import useq
+    from pymmcore_plus.metadata import SummaryMetaV1
+    from qtpy.QtWidgets import QWidget
+    from useq import MDAEvent
+
+
+class CoreViewersLink(QObject):
+
+    from ..data_wrappers import MMTensorstoreWrapper
+
+    def __init__(self, parent: QWidget, *, mmcore: CMMCorePlus | None = None):
+        super().__init__(parent)
+
+        self._mmc = mmcore or CMMCorePlus.instance()
+
+        self._current_viewer: ArrayViewer | None = None
+
+        self._mmc.mda.events.sequenceStarted.connect(self._on_sequence_started)
+        self._mmc.mda.events.frameReady.connect(self._on_frame_ready)
+        self._mmc.mda.events.sequenceFinished.connect(self._on_sequence_finished)
+
+    def _on_sequence_started(
+        self, sequence: useq.MDASequence, meta: SummaryMetaV1
+    ) -> None:
+        """Prepare the acquisition datastore."""
+        self._current_viewer = None
+
+        # pause until the viewer is ready
+        self._mmc.mda.toggle_pause()
+        print("------------------ PAUSED ------------------")
+
+        # to implement when we will get the datastore form the MDAWidget
+        # datastore = self._mda.writer if self._mda is not None else None
+        self._datastore = TensorStoreHandler()
+        # emit the sequenceStarted signal of the datastore since it is not connected
+        self._datastore.sequenceStarted(sequence, meta)
+        # connect the datastore mmcore signals
+        self._mmc.mda.events.sequenceFinished.connect(self._datastore.sequenceFinished)
+        self._mmc.mda.events.frameReady.connect(self._datastore.frameReady)
+
+        # resume the sequence
+        self._mmc.mda.toggle_pause()
+        print("------------------ RESUMED ------------------")
+
+    def _on_frame_ready(self, event: MDAEvent) -> None:
+        """Show the MDAViewer when the MDA sequence starts."""
+        print("------------------ FRAME READY ------------------")
+        print(self._current_viewer is None, self._datastore.store is None)
+        if self._current_viewer is None and self._datastore.store is not None:
+            self._current_viewer = _ArrayViewer(self._datastore.store)
+            self._current_viewer.show()
+
+    def _on_sequence_finished(self, sequence: useq.MDASequence) -> None:
+        """Reset the variables and disconnect the signals."""
+        self._mmc.mda.events.sequenceFinished.disconnect(
+            self._datastore.sequenceFinished
+        )
+        self._mmc.mda.events.frameReady.disconnect(self._datastore.frameReady)
+
+        if self._current_viewer is None and self._datastore.store is not None:
+            print("------------------ ADDING AT THE END ------------------")
+            self._current_viewer = _ArrayViewer(self._datastore.store)
+            self._current_viewer.widget().show()
+
+        breakpoint()
+
+        # self._current_viewer = None
+        # self._datastore = None
+
+
+class _ArrayViewer(ArrayViewer):
+    def __init__(self, data, **kwargs):
+        super().__init__(data, **kwargs)
+        print("ArrayViewer created")
+        print("----------------------")
+        print(type(data))
+        print(data)

--- a/src/pymmcore_gui/data_wrappers/__init__.py
+++ b/src/pymmcore_gui/data_wrappers/__init__.py
@@ -1,0 +1,5 @@
+"""Data wrappers."""
+
+from ._mm_tensorstore_wrapper import MMTensorstoreWrapper
+
+__all__ = ["MMTensorstoreWrapper"]

--- a/src/pymmcore_gui/data_wrappers/_mm_tensorstore_wrapper.py
+++ b/src/pymmcore_gui/data_wrappers/_mm_tensorstore_wrapper.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from collections.abc import Hashable, Mapping, Sequence
+from typing import Any
+
+from ndv import DataWrapper
+from pymmcore_plus.mda.handlers import TensorStoreHandler
+
+
+class MMTensorstoreWrapper(DataWrapper["TensorStoreHandler"]):
+    """Wrapper for pymmcore_plus.mda.handlers.TensorStoreHandler objects."""
+
+    def __init__(self, data: Any) -> None:
+        super().__init__(data)
+
+        self._data: TensorStoreHandler = data
+        self._dims: tuple[Hashable, ...] = ()
+        self._coords: Mapping[Hashable, Sequence] = {}
+
+    @classmethod
+    def supports(cls, obj: Any) -> bool:
+        return isinstance(obj, TensorStoreHandler)
+
+    @property
+    def dims(self) -> tuple[Hashable, ...]:
+        """Return the dimension labels for the data."""
+        if self._dims:
+            return self._dims
+
+        if (store := self._data._store) is None:
+            return ()
+        spec = store.spec().to_json()
+
+        dims = [str(x) for x in spec["transform"]["input_labels"]]
+        print("     dims1:", dims)
+
+        if isinstance(dims, Sequence) and len(dims) == len(self._data._store.domain):
+            self._dims: tuple[Hashable, ...] = tuple(str(x) for x in dims)
+            print("     self._dims1:", self._dims)
+            # self._data = self.data._store[ts.d[:].label[self._dims]]
+        else:
+            self._dims = tuple(range(len(self._data._store.domain)))
+            print("     self._dims2:", self._dims)
+
+        return self._dims
+
+    @property
+    def coords(self) -> Mapping[Hashable, Sequence]:
+        """Return the coordinates for the data."""
+        if self._coords:
+            return self._coords
+
+        if not self._dims or not self._data:
+            return {}
+
+        self._coords = {
+            i: range(s)
+            for i, s in zip(self._dims, self._data._store.domain.shape, strict=False)
+        }
+
+        return self._coords
+
+    def sizes(self) -> Mapping[Hashable, int]:
+        if not self._dims or not self._data:
+            return {}
+        return dict(zip(self._dims, self._data._store.domain.shape, strict=False))
+
+    def guess_channel_axis(self) -> Hashable | None:
+        return "c"
+
+    def isel(self, indexers: Mapping[str, int]) -> Any:
+        return self._data.isel(indexers)
+
+
+# class MMTensorstoreWrapper(DataWrapper["TensorStoreHandler"]):
+#     """Wrapper for pymmcore_plus.mda.handlers.TensorStoreHandler objects."""
+
+#     def __init__(self, data: Any) -> None:
+#         super().__init__(data)
+
+#         self._data: TensorStoreHandler = data
+
+#     @classmethod
+#     def supports(cls, obj: Any) -> bool:
+#         return isinstance(obj, TensorStoreHandler)
+
+#     def sizes(self) -> Mapping[str, int]:
+#         with suppress(Exception):
+#             return self.data.current_sequence.sizes  # type: ignore
+#         return {}
+
+#     def guess_channel_axis(self) -> Hashable | None:
+#         return "c"
+
+#     def isel(self, indexers: Mapping[str, int]) -> Any:
+#         return self.data.isel(indexers)
+
+#     def save_as_zarr(self, save_loc: str | Path) -> None:
+#         # to have access to the metadata, the generated zarr file should be opened with
+#         # the micromanager_gui.readers.TensorstoreZarrReader
+
+#         # TODO: find a way to save as ome-zarr
+
+#         import tensorstore as ts
+
+#         if (store := self.data.store) is None:
+#             return
+#         new_spec = store.spec().to_json()
+#         new_spec["kvstore"] = {"driver": "file", "path": str(save_loc)}
+#         new_ts = ts.open(new_spec, create=True).result()
+#         new_ts[:] = store.read().result()
+#         if meta_json := store.kvstore.read(".zattrs").result().value:
+#             new_ts.kvstore.write(".zattrs", meta_json).result()
+
+#     def save_as_tiff(self, save_loc: str | Path) -> None:
+#         if (store := self.data.store) is None:
+#             return
+#         reader = TensorstoreZarrReader(store)
+#         reader.write_tiff(save_loc)


### PR DESCRIPTION
Currently, if you open and then close the `MMConsole`, you cannot reopen it.
I think it should be placed in a `QWidget` when it is created the first time.