### PR TITLE
fix: hide 3d and roi buttons of preview viewer

### DIFF
--- a/src/pymmcore_gui/actions/core_actions.py
+++ b/src/pymmcore_gui/actions/core_actions.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from superqt import QIconifyIcon
+
 from ._action_info import ActionInfo, ActionKey
 
 if TYPE_CHECKING:
@@ -43,7 +45,10 @@ def _init_toggle_live(action: QCoreAction) -> None:
     mmc = action.mmc
 
     def _on_change() -> None:
-        action.setChecked(mmc.isSequenceRunning())
+        _is_running = mmc.isSequenceRunning()
+        action.setChecked(_is_running)
+        _icon = "mdi:video-off-outline" if _is_running else "mdi:video-outline"
+        action.setIcon(QIconifyIcon(_icon))
 
     mmc.events.sequenceAcquisitionStarted.connect(_on_change)
     mmc.events.continuousSequenceAcquisitionStarted.connect(_on_change)
@@ -56,7 +61,7 @@ snap_action = ActionInfo(
     key=CoreAction.SNAP,
     shortcut="Ctrl+K",
     auto_repeat=True,
-    icon="mdi-light:camera",
+    icon="mdi:camera-outline",
     on_triggered=snap_image,
 )
 

--- a/src/pymmcore_gui/widgets/image_preview/_ndv_preview.py
+++ b/src/pymmcore_gui/widgets/image_preview/_ndv_preview.py
@@ -71,6 +71,8 @@ class Streamer:
         self._wrapper = _StreamingWrapper(self)
 
         self.viewer = viewer
+        self.viewer._viewer_model.show_roi_button = False
+        self.viewer._viewer_model.show_3d_button = False
         self.process_events_on_update = process_events_on_update
 
         self._start = 0  # index of the oldest frame in the buffer


### PR DESCRIPTION
- hide 3d and roi buttons of preview viewer
- add "video-off" icon when live mode